### PR TITLE
fix `builds` / `build`* typo

### DIFF
--- a/docs/pages/development/create-development-builds.mdx
+++ b/docs/pages/development/create-development-builds.mdx
@@ -31,7 +31,7 @@ EAS Build is created by running the `eas build` command. It also creates an [**e
 
 ```json eas.json
 {
-  "builds": {
+  "build": {
     "development": {
       "developmentClient": true,
       "distribution": "internal"


### PR DESCRIPTION
# Why

Trying to use the docs to get development builds working, encountered this issue

# How

Just edited the file

# Test Plan

N/A

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
